### PR TITLE
Attempt to download the installer with curl if wget is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,12 @@
-wget "https://github.com/madhavanmalolan/N/blob/master/n?raw=true" -O /tmp/n
-chmod 700 /tmp/n
-cp /tmp/n /usr/local/sbin/
+if command -v curl > /dev/null; then
+    curl -sL "https://github.com/madhavanmalolan/N/blob/master/n?raw=true" > /tmp/n
+elif command -v wget > /dev/null; then
+    wget "https://github.com/madhavanmalolan/N/blob/master/n?raw=true" -O /tmp/n
+fi
+
+if [ -f /tmp/n ]; then
+    chmod 700 /tmp/n
+    cp /tmp/n /usr/local/sbin/
+else
+    exit 1
+fi


### PR DESCRIPTION
Attempt to download the installer with `curl` or `wget`, whichever is installed, and ensure the installer was downloaded before copying to the binaries folder.